### PR TITLE
Add ML library versions to pickle file for compatibility

### DIFF
--- a/pycaret/internal/pipeline.py
+++ b/pycaret/internal/pipeline.py
@@ -22,6 +22,7 @@ from sklearn.utils.metaestimators import if_delegate_has_method
 from sklearn.utils.validation import check_memory
 
 from pycaret.internal.utils import get_all_object_vars_and_properties, variable_return
+from pycaret.utils import __version__
 
 
 def _fit_one(transformer, X=None, y=None, message=None, **fit_params):
@@ -86,6 +87,49 @@ class Pipeline(imblearn.pipeline.Pipeline):
     def __getattr__(self, name: str):
         # override getattr to allow grabbing of final estimator attrs
         return getattr(self._final_estimator, name)
+
+    def __getstate__(self):
+        try:
+            state = super().__getstate__()
+            state.update(self.__dict__)
+        except AttributeError:
+            state = self.__dict__.copy()
+
+        return dict(state.items(), _pycaret_versions=self._pycaret_versions)
+
+    def __setstate__(self, state):
+        pickle_versions = state.get("_pycaret_versions", {})
+        if pickle_versions != self._pycaret_versions:
+            import warnings
+
+            warnings.warn("Version mismatch:\ncurrent: {}\npickle: {}".format(self._pycaret_versions, pickle_versions))
+        try:
+            super().__setstate__(state)
+        except AttributeError:
+            pass
+
+        self.__dict__.update(state)
+
+    @property
+    def _pycaret_versions(self):
+        from importlib import import_module
+
+        versions = {"pycaret": __version__}
+        ml_modules = [
+            ("sklearn", "sklearn"),
+            ("imblearn", "imblearn"),
+            ("pyod", "pyod.version"),
+            ("category-encoders", "category_encoders"),
+            ("lightgbm", "lightgbm"),
+        ]
+        for name, import_name in ml_modules:
+            try:
+                module = import_module(import_name)
+                versions[name] = module.__version__
+            except (AttributeError, ImportError, OSError):
+                pass
+
+        return versions
 
     @property
     def feature_names_in_(self):


### PR DESCRIPTION
⚠️ This PR will be directed to the pycaret/pycaret repository. ⚠️ 

## Related Issue or bug

Info about Issue or bug

Closes #[issue number that will be closed through this PR]

#### Describe the changes you've made

PyCaret 2.x uses sklearn 0.23.2, and PyCaret 3.x will always use the latest version of sklearn.
Since the versions of the various ML libraries are no longer fixed, this PR will embed the ML library versions (including sklearn) in the pickle file.
This PR was created with reference to [sklearn/base.py](https://github.com/scikit-learn/scikit-learn/blob/8175cd60e3df606905aedf2dd3ba0832e50cd963/sklearn/base.py#L326) :)

Here is an example.

```sh
# refs. https://pycaret.gitbook.io/docs/get-started/quickstart#classification
$ python3
>>> from pycaret.datasets import get_data
>>> data = get_data('diabetes')
>>> from pycaret.classification import *
>>> s = setup(data, target = 'Class variable')
>>> best = compare_models()
>>> save_model(best, 'my_best_pipeline')
>>> 
# This works fine, of course. 
>>> loaded_model = load_model('my_best_pipeline')
Transformation Pipeline and Model Successfully Saved
(Pipeline(memory=Memory(location=/var/folders/sj/n8jwy9zx4vq74qw53_3m7lxr0000gn/T/joblib),
         steps=[('numerical_imputer',
                 TransformerWrapper(exclude=None, include=['Number of times pregnant', 'Plasma glucose concentration a 2 hours in an oral glucose tolerance test', 'Diastolic blood pressure (mm Hg)', 'Triceps skin fold thickness (mm)', '2-Hour serum insulin (mu U/ml)', 'Body mass inde...
                 TransformerWrapper(exclude=None, include=[], transformer=SimpleImputer(add_indicator=False, copy=True, fill_value='constant', missing_values=nan, strategy='constant', verbose='deprecated'))),
                ['trained_model',
                 LinearDiscriminantAnalysis(covariance_estimator=None,
                                            n_components=None, priors=None,
                                            shrinkage=None, solver='svd',
                                            store_covariance=False,
                                            tol=0.0001)]],
         verbose=False), 'my_best_pipeline.pkl')

# loaded_model has its own version information
>>> loaded_model._pycaret_versions
{'pycaret': '3.0.0.rc3', 'sklearn': '1.1.1', 'imblearn': '0.9.1', 'pyod': '1.0.2', 'category-encoders': '2.5.0', 'lightgbm': '3.3.2'}
```

This will increase the availability of the pycaret models.
In an environment with the latest pycaret installed, the following snippet shows the version of the pkl file when it was created.
This allows us to recreate an environment in which the model can be executed.

```sh
# In a virtual environment with a fake updated version of pycaret installed
$ python3 peeker_sample.py my_best_pipeline
Transformation Pipeline and Model Successfully Loaded
Version mismatch:
current: {'pycaret': '3.0.0.rc4', 'sklearn': '1.1.1', 'imblearn': '0.9.1', 'pyod': '1.0.3', 'category-encoders': '2.5.0', 'lightgbm': '3.3.2'}
pickle: {'pycaret': '3.0.0.rc3', 'sklearn': '1.1.1', 'imblearn': '0.9.1', 'pyod': '1.0.2', 'category-encoders': '2.5.0', 'lightgbm': '3.3.2'}
```

```peeker_sample.py
# peeker_sample.py
import sys
import warnings

from pycaret.classification import *


def check(target):
    with warnings.catch_warnings(record=True) as w:
        warnings.simplefilter("always")
        loaded_model = load_model(target)
        for m in w:
            print(m.message)


def main():
    check(sys.argv[1])


if __name__ == "__main__":
    main()
```

#### Note

If model_only=True is passed to save_model(), this change does nothing.
In this case, it is up to the library implementation to provide version information.

ex. sklearn model stores that version.

```
>>> save_model(best, 'my_best_pipeline_model_only', model_only=True)
Transformation Pipeline and Model Successfully Saved
(RidgeClassifier(alpha=1.0, class_weight=None, copy_X=True, fit_intercept=True,
                max_iter=None, normalize='deprecated', positive=False,
                random_state=4741, solver='auto', tol=0.001), 'my_best_pipeline_model_only.pkl')
>>> loaded_model = load_model('my_best_pipeline_model_only')
Transformation Pipeline and Model Successfully Loaded
>>> type(loaded_model)
<class 'sklearn.linear_model._ridge.RidgeClassifier'>
>>> loaded_model.__getstate__()['_sklearn_version']
'1.1.1'
```


## Type of change

Please delete options that are not relevant.
<!--
Example how to mark a checkbox :-
- [x] My code follows the code style of this project.
-->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Manual testing was done with quick start (classification, regression, clustering, anomaly-detection).

## Checklist:

<!--
Example how to mark a checkbox :-
- [x] My code follows the code style of this project.
-->
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.

## Screenshots

 Original           | Updated
 :--------------------: |:--------------------:
 **original screenshot**  | <b>updated screenshot </b> |
